### PR TITLE
Add functionality to pull and tag existing images rather than building

### DIFF
--- a/util/build_docker_images
+++ b/util/build_docker_images
@@ -15,10 +15,20 @@ cat << EOF
   Usage: $0 -d docker_context_dir [OPTIONS]
 
   OPTIONS
-    -h  Display this message and exit
-    -d  Directory to find Dockerfiles/build contexts in [${DEFAULT_DOCKER_CONTEXT_DIR}]
-    -c  Container registry
-    -p  Also push built images
+  ───────
+    $(tput bold)-h$(tput sgr0)  Display this message and exit
+
+    $(tput bold)-d$(tput sgr0)  Directory to find Dockerfiles/build contexts in [${DEFAULT_DOCKER_CONTEXT_DIR}]
+
+    $(tput bold)-c$(tput sgr0)  Container registry to push images to
+
+    $(tput bold)-p$(tput sgr0)  Also push built images
+
+    $(tput bold)-s$(tput sgr0)  Source container registry; if specified, attempt to pull image(s) from the source registry rather than building locally.
+        The pulled image will be tagged with the container_registry specified by $(tput bold)-c container_registry$(tput sgr0) (default: '').
+        Can be combined with $(tput bold)-p -c container_registry$(tput sgr0) to pull, tag, and push images to a different container registry.
+
+    $(tput bold)-r$(tput sgr0)  Remove local images following push
 
 EOF
 }
@@ -105,33 +115,106 @@ build_docker_image() {
       "${docker_context_dir}"
 
     if [[ "${PUSH_IMAGES}" == 'true' ]]; then
-      log "Pushing ${tagged_image}"
-      docker push "${tagged_image}"
+      if [[ -n "${CONTAINER_REGISTRY:-}" ]]; then
+        log "Pushing ${tagged_image}"
+        docker push "${tagged_image}"
+
+        if [[ "${REMOVE_LOCAL_IMAGES}" == 'true' ]]; then
+          log "Removing pushed image"
+          docker image rm "${tagged_image}"
+        fi
+      else
+        err "[ERROR] Push images requested, but target container registry not set; set using '-c container_registry'"
+        exit 1
+      fi
     fi
   )
 }
 
-while getopts "hd:c:p" OPTION; do
+pull_docker_image() {
+  local build_env_file="$1"
+
+  (
+    # Ensure we're pulling these variables from the build_env_file
+    unset IMAGE_NAME IMAGE_TAG DOCKERFILE NOBUILD CONDA_ENVIRONMENT_TEMPLATE
+
+    set -a
+    . "${build_env_file}"
+    set +a
+
+    IMAGE_NAME=${IMAGE_NAME:-}
+    IMAGE_TAG=${IMAGE_TAG:-}
+
+    # Ensure that at minimum IMAGE_NAME and IMAGE_TAG are defined
+    if [[ -z "${IMAGE_NAME}" ]]; then
+      err "[ERROR] No IMAGE_NAME defined for docker context [${docker_context_dir}]"
+      err "[ERROR] Set IMAGE_NAME in [${build_env_file}] and try again."
+      exit 1
+    fi
+    if [[ -z "${IMAGE_TAG}" ]]; then
+      err "[ERROR] No IMAGE_TAG defined for docker context [${docker_context_dir}]"
+      err "[ERROR] Set IMAGE_TAG in [${build_env_file}] and try again."
+      exit 1
+    fi
+
+    tagged_source_image="${SOURCE_REGISTRY:+"${SOURCE_REGISTRY}/"}${IMAGE_NAME}:${IMAGE_TAG}"
+
+    log "Pulling ${tagged_source_image}"
+    docker pull "${tagged_source_image}"
+
+    tagged_dest_image="${CONTAINER_REGISTRY:+"${CONTAINER_REGISTRY}/"}${IMAGE_NAME}:${IMAGE_TAG}"
+
+    log "Tagging [${tagged_source_image}] as [${tagged_dest_image}]"
+    docker tag "${tagged_source_image}" "${tagged_dest_image}"
+
+    if [[ "${PUSH_IMAGES}" == 'true' ]]; then
+        if [[ -n "${CONTAINER_REGISTRY:-}" ]]; then
+          log "Pushing [${tagged_dest_image}]"
+          docker push "${tagged_dest_image}"
+
+          if [[ "${REMOVE_LOCAL_IMAGES}" == 'true' ]]; then
+            log "Removing pushed images"
+            docker image rm "${tagged_source_image}" "${tagged_dest_image}"
+          fi
+        else
+          err "[ERROR] Push images requested, but target container registry not set; set using '-c container_registry'"
+          exit 1
+        fi
+    fi
+  )
+}
+
+while getopts "hd:c:ps:r" OPTION; do
   case $OPTION in
     h) usage; exit ;;
     d) DOCKER_CONTEXT_DIR=$OPTARG ;;
     c) CONTAINER_REGISTRY=$OPTARG;;
     p) PUSH_IMAGES='true' ;;
+    s) SOURCE_REGISTRY=$OPTARG ;;
+    r) REMOVE_LOCAL_IMAGES='true' ;;
     \?) usage; exit ;;
   esac
 done
 
 DOCKER_CONTEXT_DIR=${DOCKER_CONTEXT_DIR:-"${DEFAULT_DOCKER_CONTEXT_DIR}"}
 PUSH_IMAGES=${PUSH_IMAGES:-'false'}
+SOURCE_REGISTRY=${SOURCE_REGISTRY:-}
+REMOVE_LOCAL_IMAGES=${REMOVE_LOCAL_IMAGES:-'false'}
 
-readonly DOCKER_CONTEXT_DIR CONTAINER_REGISTRY PUSH_IMAGES
+readonly DOCKER_CONTEXT_DIR CONTAINER_REGISTRY PUSH_IMAGES SOURCE_REGISTRY REMOVE_LOCAL_IMAGES
 
 IMAGES_TO_BUILD=$(find "${DOCKER_CONTEXT_DIR}" -type f -name build.env)
 if [[ "${#IMAGES_TO_BUILD}" -eq 0 ]]; then
   usage
+
+  log "No target images found; call using -d docker_context_dir targetting a directory with at least one build.env file."
   exit
 fi
 
 while read -r build_env_file; do
-  build_docker_image "${build_env_file}"
+  if [[ -n "${SOURCE_REGISTRY}" ]]; then
+    pull_docker_image "${build_env_file}"
+  else
+    build_docker_image "${build_env_file}"
+  fi
 done <<< "${IMAGES_TO_BUILD}"


### PR DESCRIPTION
Images must exist at the source container registry. Also added a '-r' option to remove images following push, in both normal build mode and in pull-tag-push mode.