### PR TITLE
Split uBAMs before alignment

### DIFF
--- a/docker/pbmm2/Dockerfile
+++ b/docker/pbmm2/Dockerfile
@@ -15,21 +15,3 @@ RUN apt-get -qq update \
 ARG PBMM2_VERSION
 RUN wget https://github.com/PacificBiosciences/pbmm2/releases/download/v${PBMM2_VERSION}/pbmm2 --directory-prefix /usr/local/bin/ \
 	&& chmod +x /usr/local/bin/pbmm2
-
-ARG DATAMASH_VERSION
-RUN wget https://ftp.gnu.org/gnu/datamash/datamash-${DATAMASH_VERSION}.tar.gz \
-	&& tar -zxvf datamash-${DATAMASH_VERSION}.tar.gz --directory /opt \
-	&& rm datamash-${DATAMASH_VERSION}.tar.gz
-RUN cd /opt/datamash-${DATAMASH_VERSION} \
-	&& ./configure \
-	&& make \
-	&& make check \
-	&& make install
-
-ARG PYSAM_VERSION
-# Issue with the use_2to3 library required to build pysam for setuptools > 58
-RUN python3 -m pip install setuptools==58
-RUN python3 -m pip install pysam==${PYSAM_VERSION}
-
-COPY scripts/* /opt/scripts/
-ENV PATH "${PATH}":/opt/scripts

--- a/docker/pbmm2/build.env
+++ b/docker/pbmm2/build.env
@@ -1,7 +1,5 @@
 # Tool versions
 PBMM2_VERSION=1.10.0
-DATAMASH_VERSION=1.1.0
-PYSAM_VERSION=0.16.0.1
 
 # Image info
 IMAGE_NAME=pbmm2

--- a/docker/pysam/Dockerfile
+++ b/docker/pysam/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.9-buster
+
+MAINTAINER Billy Rowell <wrowell@pacificbiosciences.com>
+
+ARG IMAGE_NAME
+ENV IMAGE_NAME "${IMAGE_NAME}"
+ARG IMAGE_TAG
+ENV IMAGE_TAG "${IMAGE_TAG}"
+
+RUN apt-get -qq update \
+	&& apt-get -qq install \
+		wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+ARG DATAMASH_VERSION
+RUN wget https://ftp.gnu.org/gnu/datamash/datamash-${DATAMASH_VERSION}.tar.gz \
+	&& tar -zxvf datamash-${DATAMASH_VERSION}.tar.gz --directory /opt \
+	&& rm datamash-${DATAMASH_VERSION}.tar.gz
+RUN cd /opt/datamash-${DATAMASH_VERSION} \
+	&& ./configure \
+	&& make \
+	&& make check \
+	&& make install
+
+ARG PYSAM_VERSION
+# Issue with the use_2to3 library required to build pysam for setuptools > 58
+RUN python3 -m pip install setuptools==58
+RUN python3 -m pip install pysam==${PYSAM_VERSION}
+
+COPY scripts/* /opt/scripts/
+ENV PATH "${PATH}":/opt/scripts

--- a/docker/pysam/build.env
+++ b/docker/pysam/build.env
@@ -1,0 +1,7 @@
+# Tool versions
+DATAMASH_VERSION=1.1.0
+PYSAM_VERSION=0.16.0.1
+
+# Image info
+IMAGE_NAME=pysam
+IMAGE_TAG=${PYSAM_VERSION}

--- a/docker/pysam/scripts/extract_read_length_and_qual.py
+++ b/docker/pysam/scripts/extract_read_length_and_qual.py
@@ -3,51 +3,56 @@
 Print read length and predicted read quality for unaligned reads (uBAM or FASTQ)
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
 import argparse
-import pysam
+import sys
 import math
+
+import pysam
 
 
 def readQualityFromBaseQuality(baseQuals):
     # Compute read quality from an array of base qualities; cap at Q60
     readLen = len(baseQuals)
-    expectedErrors = sum([math.pow(10, -0.1*x) for x in baseQuals])
-    return min(60,math.floor(-10*math.log10(expectedErrors/readLen)))
+    expectedErrors = sum([math.pow(10, -0.1 * x) for x in baseQuals])
+    return min(60, math.floor(-10 * math.log10(expectedErrors / readLen)))
 
 
 def main(args):
     if args.readsin.endswith(".bam"):
+        save = pysam.set_verbosity(0)  # suppress [E::idx_find_and_load]
         bamin = pysam.AlignmentFile(args.readsin, check_sq=False)
+        pysam.set_verbosity(save)  # restore warnings
         for b in bamin:
-            if b.has_tag("rq"): # get read qualitiy from "rq" BAM tag if available
+            if b.has_tag("rq"):  # get read qualitiy from "rq" BAM tag if available
                 errorrate = 1.0 - b.get_tag("rq")
-                readqv = 60 if errorrate == 0 else math.floor(-10*math.log10(errorrate))
+                readqv = (
+                    60 if errorrate == 0 else math.floor(-10 * math.log10(errorrate))
+                )
             else:
                 readqv = readQualityFromBaseQuality(b.query_qualities)
-
             print("%s\t%d\t%d" % (b.query_name, len(b.query_sequence), readqv))
         bamin.close()
     elif args.readsin.endswith(".fastq") or args.readsin.endswith(".fastq.gz"):
         fastqin = pysam.FastxFile(args.readsin)
         for r in fastqin:
             readqv = readQualityFromBaseQuality(r.get_quality_array())
-            print ("%s\t%d\t%d" % (r.name, len(r.sequence), readqv))
+            print("%s\t%d\t%d" % (r.name, len(r.sequence), readqv))
         fastqin.close()
     else:
         sys.exit("Input file name must end in .bam or .fastq")
 
 
 if __name__ == "__main__":
-    """ This is executed when run from the command line """
+    """This is executed when run from the command line"""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("readsin", help="Unaligned reads (BAM or FASTQ)")
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s (version {version})".format(version=__version__))
-
+        version="%(prog)s (version {version})".format(version=__version__),
+    )
     args = parser.parse_args()
     main(args)

--- a/docker/pysam/scripts/split_bam.py
+++ b/docker/pysam/scripts/split_bam.py
@@ -27,7 +27,7 @@ def main(args):
                 )
             bamout.write(record)
             recordcount += 1
-            if recordcount == int(args.chunksize):
+            if recordcount == args.chunksize:
                 bamout.close()
                 recordcount = 0
                 chunk += 1
@@ -37,8 +37,8 @@ def main(args):
 if __name__ == "__main__":
     """This is executed when run from the command line"""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("ubam", help="Unaligned reads BAM")
-    parser.add_argument("chunksize", help="Maximum number of reads per chunk")
+    parser.add_argument("ubam", type=str, help="Unaligned reads BAM")
+    parser.add_argument("chunksize", type=int, help="Maximum number of reads per chunk")
     parser.add_argument(
         "--version",
         action="version",

--- a/docker/pysam/scripts/split_bam.py
+++ b/docker/pysam/scripts/split_bam.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Split uBAM file into chunks of chunksize reads
+"""
+
+__version__ = "0.1.0"
+
+
+import argparse
+from os.path import basename
+
+import pysam
+
+
+def main(args):
+    save = pysam.set_verbosity(0)  # suppress [E::idx_find_and_load]
+    with pysam.AlignmentFile(args.ubam, check_sq=False) as bamin:
+        pysam.set_verbosity(save)  # restore warnings
+        recordcount = 0
+        chunk = 0
+        for record in bamin:
+            if recordcount == 0:
+                bamout = pysam.AlignmentFile(
+                    basename(args.ubam).replace(".bam", f".chunk_{chunk}.bam"),
+                    "wb",
+                    template=bamin,
+                )
+            bamout.write(record)
+            recordcount += 1
+            if recordcount == int(args.chunksize):
+                bamout.close()
+                recordcount = 0
+                chunk += 1
+    bamout.close()
+
+
+if __name__ == "__main__":
+    """This is executed when run from the command line"""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("ubam", help="Unaligned reads BAM")
+    parser.add_argument("chunksize", help="Maximum number of reads per chunk")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s (version {version})".format(version=__version__),
+    )
+
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
Experimental branch to split uBAMs before alignment.

- moved scripts/extract_read_length_and_qual.py to this image
- added scripts/split_bam.py to this image
  - splits a uBAM into chunks of max size `chunksize`

sha256:7c793937b5c0472c34b820b413decef1b74ce02767eafa65627da7e6e5028bf9