### PR TITLE
Update to HiFiCNV v0.1.7

### DIFF
--- a/docker/hificnv/build.env
+++ b/docker/hificnv/build.env
@@ -1,5 +1,5 @@
 # Tool versions
-HIFICNV_VERSION=0.1.6
+HIFICNV_VERSION=0.1.7
 BCFTOOLS_VERSION=1.16
 
 # Image info


### PR DESCRIPTION
sha256:1f1bacf210b173b982572cd56802f73f59f62aea14a6a47e7ac8caeef3766ceb

- Will require changes to CN example filename parameters: 

`expected_cn.{hg19,hg38,hs37d5}.{XX,XY}.bed`
`cnv.excluded_regions.{hg19,hg38,hs37d5}.bed.gz{,.tbi}`
`cnv.excluded_regions.common_50.hg38.bed.gz{,.tbi}` (only available for hg38)