### PR TITLE
GLnexus update and hosting

### DIFF
--- a/docker/glnexus/build.env
+++ b/docker/glnexus/build.env
@@ -1,0 +1,2 @@
+IMAGE_NAME=glnexus
+IMAGE_TAG=v1.4.3

--- a/docker/glnexus/readme
+++ b/docker/glnexus/readme
@@ -1,0 +1,3 @@
+# To push glnexus to your repo, run:
+
+./util/build_docker_images -s ghcr.io/dnanexus-rnd/glnexus:v1.4.3 -d docker/glnexus/ -c ${repo} -p

--- a/docker/glnexus/readme
+++ b/docker/glnexus/readme
@@ -1,3 +1,3 @@
 # To push glnexus to your repo, run:
 
-./util/build_docker_images -s ghcr.io/dnanexus-rnd/glnexus:v1.4.3 -d docker/glnexus/ -c ${repo} -p
+./util/build_docker_images -s ghcr.io/dnanexus-rnd/ -d docker/glnexus/ -c ${repo} -p


### PR DESCRIPTION
Update to GLnexus 1.4.3, and host it on Quay to address https://github.com/broadinstitute/cromwell/issues/6827