### PR TITLE
fix: Use pyyaml SafeLoader to suppress deprecation warning.

### DIFF
--- a/docker/pyyaml/build.env
+++ b/docker/pyyaml/build.env
@@ -1,5 +1,5 @@
 # Image revision
-IMAGE_BUILD=3
+IMAGE_BUILD=4
 
 # Tool versions
 PYYAML_VERSION=5.3.1

--- a/docker/pyyaml/scripts/calculate_phrank.py
+++ b/docker/pyyaml/scripts/calculate_phrank.py
@@ -243,7 +243,7 @@ def main(args):
     )
 
     yamlfile = open(args.cohortyaml, "r")
-    cohort_list = yaml.load("".join(yamlfile))
+    cohort_list = yaml.load("".join(yamlfile), Loader=yaml.SafeLoader)
     yamlfile.close()
 
     cohort = None

--- a/docker/pyyaml/scripts/parse_cohort.py
+++ b/docker/pyyaml/scripts/parse_cohort.py
@@ -3,7 +3,7 @@
 import json
 from argparse import ArgumentParser
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 
 def _load_cohort_info(cohort_json_file):
@@ -36,7 +36,7 @@ def json_to_yaml(cohort_json_file, output_yaml_file):
     for sample in cohort_info["samples"]:
         parents = [
             parent
-            for parent in [sample.get("father_id", None), sample.get("mother_id", None)]
+            for parent in [sample.get("mother_id", None), sample.get("father_id", None)]
             if parent is not None
         ]
         sex = sample.get("sex", None)

--- a/docker/pyyaml/scripts/yaml2ped.py
+++ b/docker/pyyaml/scripts/yaml2ped.py
@@ -34,7 +34,7 @@ AFFECTEDSTATUS = {'unaffecteds': 1, 'affecteds': 2}
 def find_cohort(args):
     """Find entry for cohortid within cohortyaml."""
     with open(args.cohortyaml, 'r') as yamlfile:
-        cohort_list = yaml.load(yamlfile, Loader=yaml.FullLoader)
+        cohort_list = yaml.load(yamlfile, Loader=yaml.SafeLoader)
     for cohort in cohort_list:
         if cohort['id'] == args.cohortid:
             return cohort


### PR DESCRIPTION
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

This should also address errors about unsafe loading, like:
```bash
/opt/scripts/calculate_phrank.py:246: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  cohort_list = yaml.load("".join(yamlfile))
```

sha256:8749239ba12a78d899f0dba4f55ddc260c42d4bfa60895bd11a628d4cfdef635