### PR TITLE
Updates to json2ped to allow more flexible input.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Populated conda environments
 *.populated.yaml
+venv
+__pycache__
+.pytest_cache
+.ruff_cache

--- a/docker/wgs_tertiary/build.env
+++ b/docker/wgs_tertiary/build.env
@@ -1,9 +1,9 @@
 # Image revision
-IMAGE_BUILD=2
+IMAGE_BUILD=3
 
 # Software version
 ZENODO_RECORD=8415406
-WORKFLOW_VERSION=1.0.2
+WORKFLOW_VERSION=2.0.0
 
 # Image info
 IMAGE_NAME=wgs_tertiary

--- a/docker/wgs_tertiary/scripts/json2ped.py
+++ b/docker/wgs_tertiary/scripts/json2ped.py
@@ -11,7 +11,7 @@ Output PED columns:
 6. phenotype (1=unaffected; 2=affected)
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 import json
 import csv
@@ -19,45 +19,45 @@ import sys
 
 
 SEX = {"MALE": "1", "M": "1", "FEMALE": "2", "F": "2"}
-STATUS = {False: "1", True: "2"}
+STATUS = {False: "1", True: "2", "false": "1", "true": "2"}
 
 
 def parse_sample(family_id, sample):
-    """For a sample struct, return a list of PED fields."""
-    return [
-        family_id,
-        sample["sample_id"],
-        sample.get("father_id", "."),
-        sample.get("mother_id", "."),
-        SEX.get(sample.get("sex", ".").upper(), "."),  # all cases accepted
-        STATUS.get(sample.get("affected"), "0"),
-    ]
+  """For a sample struct, return a list of PED fields."""
+  return [
+    family_id,
+    sample["sample_id"],
+    sample.get("father_id", "."),
+    sample.get("mother_id", "."),
+    SEX.get(sample.get("sex", ".").upper(), "."),  # all cases accepted
+    STATUS.get(sample.get("affected"), "0"),
+  ]
 
 
-def parse_family(family):
-    """For a family struct, return a list of lists of PED fields for each sample."""
-    family_id = family["family_id"]
-    samples = []
-    for sample in family["samples"]:
-        samples.append(parse_sample(family_id, sample))
-    return samples
+def parse_family(family_id, family):
+  """For a family struct, return a list of lists of PED fields for each sample."""
+  samples = []
+  for sample in family:
+    samples.append(parse_sample(family_id, sample))
+  return samples
 
 
 def write_ped(samples):
-    """Write PED format to stdout."""
-    tsv_writer = csv.writer(sys.stdout, delimiter="\t")
-    for sample in samples:
-        tsv_writer.writerow(sample)
+  """Write PED format to stdout."""
+  tsv_writer = csv.writer(sys.stdout, delimiter="\t")
+  for sample in samples:
+    tsv_writer.writerow(sample)
 
 
 def main():
-    with open(sys.argv[1], "r") as family:
-        samples = parse_family(json.load(family))
-        write_ped(samples)
+  family_id = sys.argv[2]
+  with open(sys.argv[1], "r") as family:
+    samples = parse_family(family_id, json.load(family))
+    write_ped(samples)
 
 
 if __name__ == "__main__":
-    if sys.argv[1] in ["-v", "--version"]:
-        print(__version__)
-        sys.exit(0)
-    main()
+  if sys.argv[1] in ["-v", "--version"]:
+    print(__version__)
+    sys.exit(0)
+  main()

--- a/docker/wgs_tertiary/scripts/test_json2ped.py
+++ b/docker/wgs_tertiary/scripts/test_json2ped.py
@@ -4,68 +4,74 @@ from json2ped import parse_sample, parse_family
 
 
 def test_parse_sample():
-    f_id = "f"
-    s = {"sample_id": "s", "sex": "MALE", "affected": True}
-    assert parse_sample(f_id, s) == ["f", "s", ".", ".", "1", "2"]
+  f_id = "f"
+  s = {"sample_id": "s", "sex": "MALE", "affected": True}
+  assert parse_sample(f_id, s) == ["f", "s", ".", ".", "1", "2"]
 
 
 def test_parse_family_trio():
-    f = {
-        "family_id": "f",
-        "samples": [
-            {"sample_id": "s", "sex": "MALE", "father_id": "d", "mother_id": "m", "affected": True},
-            {"sample_id": "d", "sex": "MALE", "affected": False},
-            {"sample_id": "m", "sex": "FEMALE", "affected": False}
-        ],
-    }
-    assert parse_family(f) == [
-        ["f", "s", "d", "m", "1", "2"],
-        ["f", "d", ".", ".", "1", "1"],
-        ["f", "m", ".", ".", "2", "1"],
-    ]
+  f_id = "f"
+  f = [
+    {
+      "sample_id": "s",
+      "sex": "MALE",
+      "father_id": "d",
+      "mother_id": "m",
+      "affected": True,
+    },
+    {"sample_id": "d", "sex": "MALE", "affected": False},
+    {"sample_id": "m", "sex": "FEMALE", "affected": False},
+  ]
+  assert parse_family(f_id, f) == [
+    ["f", "s", "d", "m", "1", "2"],
+    ["f", "d", ".", ".", "1", "1"],
+    ["f", "m", ".", ".", "2", "1"],
+  ]
 
 
 def test_sex_unknown():
-    f_id = "f"
-    s = {"sample_id": "s", "affected": True}
-    assert parse_sample(f_id, s)[4] == "."
+  f_id = "f"
+  s = {"sample_id": "s", "affected": True}
+  assert parse_sample(f_id, s)[4] == "."
 
 
 def test_status_unknown():
-    f_id = "f"
-    s = {"sample_id": "s", "sex": "MALE"}
-    assert parse_sample(f_id, s)[5] == "0"
+  f_id = "f"
+  s = {"sample_id": "s", "sex": "MALE"}
+  assert parse_sample(f_id, s)[5] == "0"
 
 
 def test_sex_strings():
-    """Reported sex.
-    (1=male; 2=female; .=unknown)"""
-    f = {
-        "family_id": "f",
-        "samples": [
-            {"sample_id": "a", "sex": "MALE",},
-            {"sample_id": "a", "sex": "Male",},
-            {"sample_id": "b", "sex": "M",},
-            {"sample_id": "b", "sex": "m",},
-            {"sample_id": "c", "sex": "FEMALE", },
-            {"sample_id": "c", "sex": "Female",},
-            {"sample_id": "d", "sex": "F",},
-            {"sample_id": "d", "sex": "f",},
-            {"sample_id": "e", "sex": "UNKNOWN",},
-            {"sample_id": "f",}
-        ],
-    }
-    assert [_[4] for _ in parse_family(f)] == ["1", "1", "1", "1", "2", "2", "2", "2", ".", "."]
+  """Reported sex.
+  (1=male; 2=female; .=unknown)"""
+  f_id = "f"
+  f = [
+    {"sample_id": "a", "sex": "MALE"},
+    {"sample_id": "a", "sex": "Male"},
+    {"sample_id": "b", "sex": "M"},
+    {"sample_id": "b", "sex": "m"},
+    {"sample_id": "c", "sex": "FEMALE"},
+    {"sample_id": "c", "sex": "Female"},
+    {"sample_id": "d", "sex": "F"},
+    {"sample_id": "d", "sex": "f"},
+    {"sample_id": "e", "sex": "UNKNOWN"},
+    {"sample_id": "f"},
+  ]
+  assert [_[4] for _ in parse_family(f_id, f)] == [
+    "1", "1", "1", "1",
+    "2", "2", "2", "2",
+    ".", ".",
+  ]
 
 
 def test_status_strings():
-    """Field 6: phenotype (1=unaffected; 2=affected, 0=missing)"""
-    f = {
-        "family_id": "f",
-        "samples": [
-            {"sample_id": "a","affected": True,},
-            {"sample_id": "b","affected": False,},
-            {"sample_id": "b"},
-        ],
-    }
-    assert [_[5] for _ in parse_family(f)] == ["2", "1", "0"]
+  """Field 6: phenotype (1=unaffected; 2=affected, 0=missing)"""
+  f_id = "f"
+  f = [
+    {"sample_id": "a", "affected": True},
+    {"sample_id": "b", "affected": False},
+    {"sample_id": "c", "affected": "true"},
+    {"sample_id": "d", "affected": "false"},
+    {"sample_id": "e"},
+  ]
+  assert [_[5] for _ in parse_family(f_id, f)] == ["2", "1", "2", "1", "0"]


### PR DESCRIPTION
- expected input structure for json2ped.py has changed; now expects 1) json array of sample structs and 2) family id as a separate string
- string "true"/"false" are now allowed for affected status, in addition to boolean True/False

wgs_tertiary sha256:f3d26eed0649d316e55f2b18add7cd374c6e627c3473a7ea60d46dcf944717a5