### PR TITLE
Fixed case where metadata values are null in json2ped.py

### DIFF
--- a/docker/wgs_tertiary/build.env
+++ b/docker/wgs_tertiary/build.env
@@ -1,9 +1,9 @@
 # Image revision
-IMAGE_BUILD=4
+IMAGE_BUILD=1
 
 # Software version
 ZENODO_RECORD=8415406
-WORKFLOW_VERSION=2.0.0
+WORKFLOW_VERSION=2.0.1
 
 # Image info
 IMAGE_NAME=wgs_tertiary

--- a/docker/wgs_tertiary/scripts/json2ped.py
+++ b/docker/wgs_tertiary/scripts/json2ped.py
@@ -11,14 +11,14 @@ Output PED columns:
 6. phenotype (1=unaffected; 2=affected)
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 import json
 import csv
 import sys
 
 
-SEX = {"MALE": "1", "M": "1", "FEMALE": "2", "F": "2"}
+SEX = {"MALE": "1", "M": "1", "FEMALE": "2", "F": "2", ".": "."}
 STATUS = {False: "1", True: "2"}
 
 
@@ -27,9 +27,9 @@ def parse_sample(family_id, sample):
   return [
     family_id,
     sample["sample_id"],
-    sample.get("father_id", "."),
-    sample.get("mother_id", "."),
-    SEX.get(sample.get("sex", ".").upper(), "."),  # all cases accepted
+    sample.get("father_id", ".") if sample.get("father_id", ".") else ".",
+    sample.get("mother_id", ".") if sample.get("mother_id", ".") else ".",
+    SEX.get(sample.get("sex", ".") if sample.get("sex", ".") else ".", ".").upper(),
     STATUS.get(sample.get("affected"), "0"),
   ]
 


### PR DESCRIPTION
wgs_tertiary:8415406_2.0.1_build1: digest: sha256:d1a7697affa4298a584e7973acccde57c723f433ffb9402cb63bfbf9b730c752

Previously, if sex was unset (null) for the family.wdl entrypoint, `write_ped_phrank` would fail.