### PR TITLE
fix: Correct path to k8 binary.

### DIFF
--- a/docker/gfatools/Dockerfile
+++ b/docker/gfatools/Dockerfile
@@ -20,7 +20,7 @@ RUN wget https://github.com/attractivechaos/k8/releases/download/v${K8_VERSION}/
 	&& tar --no-same-owner -jxvf k8-${K8_VERSION}.tar.bz2 --directory /opt \
 	&& rm k8-${K8_VERSION}.tar.bz2
 RUN cd /opt/k8-${K8_VERSION} \
-	&& ln -s /opt/k8-${K8_VERSION}/k8-Linux /usr/local/bin/k8
+	&& ln -s /opt/k8-${K8_VERSION}/k8-x86_64-Linux /usr/local/bin/k8
 
 ARG CALN50_GIT_HASH
 WORKDIR /opt

--- a/docker/gfatools/build.env
+++ b/docker/gfatools/build.env
@@ -1,5 +1,5 @@
 # Image revision
-IMAGE_BUILD=1
+IMAGE_BUILD=2
 
 # Tool versions
 GFATOOLS_VERSION=0.5


### PR DESCRIPTION
0.5_34e0fcf_build2: digest: sha256:0ec85987c043e84fd492e9e0908261e365b70a6d4eaf797c39a9c1da695a10ce