### PR TITLE
bump: Updated Severus to 1.7, using uv to install.

### DIFF
--- a/docker/severus/build.env
+++ b/docker/severus/build.env
@@ -2,7 +2,7 @@
 IMAGE_BUILD=1
 
 # Tool versions
-SEVERUS_VERSION=92d014e
+SEVERUS_VERSION=1.7
 
 # Image info
 IMAGE_NAME=severus


### PR DESCRIPTION
1.7_build1: digest: sha256:24b28384ff56db4832316a87d585a7ffb094c6b7d26129f90dec2e0f11282a5c