### PR TITLE
update: Change base image to the latest version for lima and pbcore

### DIFF
--- a/docker/lima/Dockerfile
+++ b/docker/lima/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pacbio/pb_wdl_base@sha256:ef224ec6b77c959baf24bb3c06189acfc62300af92e1e74d311e281735749c56
+FROM quay.io/pacbio/pb_wdl_base@sha256:1fa8b22abd2e32afe18cb2ff41dd0426d813a0450515efc0e626cf35f5658af3
 
 LABEL maintainer="Billy Rowell <wrowell@pacb.com>"
 

--- a/docker/pbcore/Dockerfile
+++ b/docker/pbcore/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pacbio/pb_wdl_base@sha256:ef224ec6b77c959baf24bb3c06189acfc62300af92e1e74d311e281735749c56
+FROM quay.io/pacbio/pb_wdl_base@sha256:1fa8b22abd2e32afe18cb2ff41dd0426d813a0450515efc0e626cf35f5658af3
 LABEL maintainer="Jocelyne Bruand <jbruand@pacb.com>"
 
 ARG IMAGE_NAME


### PR DESCRIPTION
lima
26.2.1_build1: digest: sha256:5af715e0f1be46a847ba9a0bc30766462a9615d1fae684e94276e84d3581d17a

pbcore
2.6.0_build1: digest: sha256:85010964913fc7f2f0aaf413ece941427380088e6dd96e5730af9373180640ad