### PR TITLE
New base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+SHELL := /bin/bash
+
+BUILD_SCRIPT := ./util/build_docker_images
+
+# Target container registry; required for push and mirror targets.
+# Usage: make push-hifiasm REMOTE_REPO=quay.io/pacbio
+REMOTE_REPO ?=
+
+# ──────────────────────────────────────────────
+# Docker images (subdirectories of docker/)
+# ──────────────────────────────────────────────
+DOCKER_IMAGES := $(notdir $(patsubst %/,%,$(wildcard docker/*/)))
+
+# ──────────────────────────────────────────────
+# Mirror images (subdirectories of mirror/)
+# Each entry is: <name>:<source-registry>
+# ──────────────────────────────────────────────
+MIRROR_DEEPVARIANT_SRC     := google
+MIRROR_GLNEXUS_SRC         := ghcr.io/dnanexus-rnd/
+
+MIRROR_IMAGES := deepvariant glnexus
+
+# ──────────────────────────────────────────────
+# Phony declarations
+# ──────────────────────────────────────────────
+.PHONY: help #\
+	build-all $(addprefix build-,$(DOCKER_IMAGES)) \
+	push-all   $(addprefix push-,$(DOCKER_IMAGES)) \
+	mirror-all $(addprefix mirror-,$(MIRROR_IMAGES))
+
+.DEFAULT_GOAL := help
+
+# ──────────────────────────────────────────────
+# Guard macro — enforces REMOTE_REPO is set
+# ──────────────────────────────────────────────
+define _require_remote_repo
+	@if [[ -z "$(REMOTE_REPO)" ]]; then \
+		echo ""; \
+		echo "  ERROR: REMOTE_REPO is not set."; \
+		echo "  Usage: make $@ REMOTE_REPO=<registry>  (e.g. quay.io/pacbio)"; \
+		echo ""; \
+		exit 1; \
+	fi
+endef
+
+# ──────────────────────────────────────────────
+# Help
+# ──────────────────────────────────────────────
+help: ## Show this help message
+	@awk 'BEGIN { \
+		FS = ":.*##"; \
+		printf "\nUsage:\n  make \033[36m<target>\033[0m [REMOTE_REPO=<registry>]\n" \
+	} \
+	/^[a-zA-Z_0-9%-]+:.*?##/ { printf "  \033[36m%-32s\033[0m %s\n", $$1, $$2 } \
+	/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' \
+	$(MAKEFILE_LIST)
+	@echo ""
+
+##@ Build (local only)
+
+# build-all: $(addprefix build-,$(DOCKER_IMAGES)) ## Build all docker images locally
+
+build-%: ## Build a single image locally
+	@if [[ ! -d docker/$* ]]; then \
+		echo ""; \
+		echo "  ERROR: Unknown image '$*'."; \
+		echo "  Valid images: $(DOCKER_IMAGES)"; \
+		echo ""; \
+		exit 1; \
+	fi
+	$(BUILD_SCRIPT) -d docker/$*
+
+##@ Push (requires REMOTE_REPO=<registry>)
+
+# push-all: $(addprefix push-,$(DOCKER_IMAGES)) ## Build and push all images to REMOTE_REPO
+
+push-%: ## Build and push a single image to REMOTE_REPO
+	$(call _require_remote_repo)
+	@if [[ ! -d docker/$* ]]; then \
+		echo ""; \
+		echo "  ERROR: Unknown image '$*'."; \
+		echo "  Valid images: $(DOCKER_IMAGES)"; \
+		echo ""; \
+		exit 1; \
+	fi
+	$(BUILD_SCRIPT) -d docker/$* -p -c $(REMOTE_REPO)
+
+##@ Mirror upstream images (requires REMOTE_REPO=<registry>)
+
+# mirror-all: $(addprefix mirror-,$(MIRROR_IMAGES)) ## Mirror all upstream images to REMOTE_REPO
+
+mirror-deepvariant: ## Mirror google/deepvariant to REMOTE_REPO
+	$(call _require_remote_repo)
+	$(BUILD_SCRIPT) -s $(MIRROR_DEEPVARIANT_SRC) -d mirror/deepvariant -p -c $(REMOTE_REPO)
+	$(BUILD_SCRIPT) -s $(MIRROR_DEEPVARIANT_SRC) -d mirror/deepvariant_gpu -p -c $(REMOTE_REPO)
+
+mirror-glnexus: ## Mirror ghcr.io/dnanexus-rnd/glnexus to REMOTE_REPO
+	$(call _require_remote_repo)
+	$(BUILD_SCRIPT) -s $(MIRROR_GLNEXUS_SRC) -d mirror/glnexus -p -c $(REMOTE_REPO)

--- a/docker/pb_wdl_base/Dockerfile
+++ b/docker/pb_wdl_base/Dockerfile
@@ -1,11 +1,18 @@
 FROM ubuntu:26.04
 
-LABEL maintainer="Billy Rowell <wrowell@pacb.com>"
-
 ARG IMAGE_NAME
-ENV IMAGE_NAME="${IMAGE_NAME}"
 ARG IMAGE_TAG
-ENV IMAGE_TAG="${IMAGE_TAG}"
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_VENDOR
+ARG IMAGE_URL
+ARG IMAGE_MAINTAINER
+
+LABEL org.opencontainers.image.title="${IMAGE_NAME}" \
+      org.opencontainers.image.description="${IMAGE_DESCRIPTION}" \
+      org.opencontainers.image.authors="${IMAGE_MAINTAINER}" \
+      org.opencontainers.image.vendor="${IMAGE_VENDOR}" \
+      org.opencontainers.image.url="${IMAGE_URL}" \
+      org.opencontainers.image.version="${IMAGE_TAG}"
 
 RUN apt-get -qq update \
 	&& apt-get -qq -y upgrade \
@@ -21,6 +28,8 @@ RUN apt-get -qq update \
 		libncurses5-dev \
 		libcurl4-openssl-dev \
 		libdeflate-dev \
+		libssl-dev \
+		libgsl-dev \
 		jq \
 		gawk \
 		parallel \
@@ -32,40 +41,52 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 ENV UV_PYTHON_INSTALL_DIR=/opt
 ARG UV_PYTHON_VERSION
 ENV UV_PYTHON_VERSION="${UV_PYTHON_VERSION}"
-RUN uv venv /opt/venv --python "${UV_PYTHON_VERSION}"
-ENV VIRTUAL_ENV=/opt/venv
+ENV VIRTUAL_ENV="/opt/venv"
 ENV PATH="/opt/venv/bin:$PATH"
-RUN ln -s $(uv python find "${UV_PYTHON_VERSION}") /usr/local/bin/python3
-RUN ln -s $(uv python find "${UV_PYTHON_VERSION}") /usr/local/bin/python
-RUN chmod -R o+rw /opt/venv /opt/
-RUN touch /.python_history && chmod a+rw /.python_history
+RUN uv venv "${VIRTUAL_ENV}" --python "${UV_PYTHON_VERSION}" \
+	&& ln -s $(uv python find "${UV_PYTHON_VERSION}") /usr/local/bin/python3 \
+	&& ln -s $(uv python find "${UV_PYTHON_VERSION}") /usr/local/bin/python \
+	&& chmod -R o+rw "${VIRTUAL_ENV}" /opt/ \
+	&& touch /.python_history && chmod a+rw /.python_history
 
 ARG HTSLIB_VERSION
-RUN wget https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2 \
-	&& tar --no-same-owner -jxvf htslib-${HTSLIB_VERSION}.tar.bz2 --directory /opt \
-	&& rm htslib-${HTSLIB_VERSION}.tar.bz2
-RUN cd /opt/htslib-${HTSLIB_VERSION} \
+RUN wget "https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2" \
+	&& tar --no-same-owner -jxvf "htslib-${HTSLIB_VERSION}.tar.bz2" --directory /opt \
+	&& rm "htslib-${HTSLIB_VERSION}.tar.bz2" \
+	&& cd "/opt/htslib-${HTSLIB_VERSION}" \
+	&& ./configure \
+		--enable-libcurl \
+		--enable-gcs \
+		--enable-s3 \
+		--with-libdeflate \
 	&& make -j \
-	&& make install
+	&& make install \
+	&& ldconfig \
+	&& make clean
 
 ARG BCFTOOLS_VERSION
-RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 \
-	&& tar --no-same-owner -jxvf bcftools-${BCFTOOLS_VERSION}.tar.bz2 --directory /opt \
-	&& rm bcftools-${BCFTOOLS_VERSION}.tar.bz2
-RUN cd /opt/bcftools-${BCFTOOLS_VERSION} \
+RUN wget "https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2" \
+	&& tar --no-same-owner -jxvf "bcftools-${BCFTOOLS_VERSION}.tar.bz2" --directory /opt \
+	&& rm "bcftools-${BCFTOOLS_VERSION}.tar.bz2" \
+	&& cd "/opt/bcftools-${BCFTOOLS_VERSION}" \
+	&& ./configure --with-htslib=system --enable-libgsl \
 	&& make -j \
-	&& make install
+	&& make install \
+	&& make clean
+ENV BCFTOOLS_PLUGINS=/usr/local/libexec/bcftools
 
 ARG SAMTOOLS_VERSION
-RUN wget https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2 \
-	&& tar --no-same-owner -jxvf samtools-${SAMTOOLS_VERSION}.tar.bz2 --directory /opt \
-	&& rm samtools-${SAMTOOLS_VERSION}.tar.bz2
-RUN cd /opt/samtools-${SAMTOOLS_VERSION} \
+RUN wget "https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2" \
+	&& tar --no-same-owner -jxvf "samtools-${SAMTOOLS_VERSION}.tar.bz2" --directory /opt \
+	&& rm "samtools-${SAMTOOLS_VERSION}.tar.bz2" \
+	&& cd "/opt/samtools-${SAMTOOLS_VERSION}" \
+	&& ./configure --with-htslib=system \
 	&& make -j \
-	&& make install
+	&& make install \
+	&& make clean
 
 ARG BEDTOOLS_VERSION
-RUN wget https://github.com/arq5x/bedtools2/releases/download/v${BEDTOOLS_VERSION}/bedtools.static \
+RUN wget "https://github.com/arq5x/bedtools2/releases/download/v${BEDTOOLS_VERSION}/bedtools.static" \
 		-O /usr/local/bin/bedtools \
 	&& chmod +x /usr/local/bin/bedtools
 
@@ -88,3 +109,9 @@ RUN uv pip install \
 	"seaborn~=${SEABORN_VERSION}" \
 	"pysam~=${PYSAM_VERSION}" \
 	"biopython~=${BIOPYTHON_VERSION}"
+
+RUN htsfile --version \
+	&& samtools --version \
+	&& bcftools --version \
+	&& bcftools plugin --list \
+	&& bedtools --version

--- a/docker/pb_wdl_base/build.env
+++ b/docker/pb_wdl_base/build.env
@@ -1,5 +1,5 @@
 # Image revision
-IMAGE_BUILD=3
+IMAGE_BUILD=4
 
 # Tool versions
 HTSLIB_VERSION=1.23.1
@@ -17,3 +17,8 @@ BIOPYTHON_VERSION=1.86
 # Image info
 IMAGE_NAME=pb_wdl_base
 IMAGE_TAG=build${IMAGE_BUILD}
+
+IMAGE_DESCRIPTION="Base image for WDL pipelines. Contains Python 3 and commonly used Python packages, as well as htslib, samtools, bcftools, and bedtools."
+IMAGE_VENDOR="PacBio"
+IMAGE_URL="https://github.com/PacificBiosciences/wdl-dockerfiles"
+IMAGE_MAINTAINER="Billy Rowell <wrowell@pacb.com>"

--- a/mirror/deepvariant/build.env
+++ b/mirror/deepvariant/build.env
@@ -1,2 +1,2 @@
 IMAGE_NAME=deepvariant
-IMAGE_TAG=1.9.0
+IMAGE_TAG=1.10.0

--- a/mirror/deepvariant_gpu/build.env
+++ b/mirror/deepvariant_gpu/build.env
@@ -1,2 +1,2 @@
 IMAGE_NAME=deepvariant
-IMAGE_TAG=1.9.0-gpu
+IMAGE_TAG=1.10.0-gpu

--- a/mirror/pharmcat/build.env
+++ b/mirror/pharmcat/build.env
@@ -1,2 +1,0 @@
-IMAGE_NAME=pharmcat
-IMAGE_TAG=2.15.4

--- a/mirror/pharmcat/readme
+++ b/mirror/pharmcat/readme
@@ -1,3 +1,0 @@
-# To push glnexus to your repo, run:
-
-./util/build_docker_images -s pgkb/pharmcat -d mirror/pharmcat/ -c ${repo} -p


### PR DESCRIPTION
The core here is a new base container.

build4: digest: sha256:03cb3c01937eccc907f8ad71c87b258581504572205fe3f31a657e318f3564ae

- moved image metadata to build.env
- using the preferred `org.opencontainers.image.*` metadata style
- base container is ubuntu 26.04
- base python is 3.14.5, installed and managed by uv
- python module versions updated
- htslib is now compiled with libdeflate, libcurl, s3, and gcs support; samtools/bcftools built with support as well
- bcftools plugins are now available in env
- `make clean` after each build
- built-in smoketest

I've also added a makefile to simplify builds.

Unrelated changes:
- updated deepvariant version in mirror
- removed pharmcat mirror