### PR TITLE
first pass at the bowhead build

### DIFF
--- a/docker/bowhead/Dockerfile
+++ b/docker/bowhead/Dockerfile
@@ -1,0 +1,23 @@
+FROM quay.io/pacbio/pb_wdl_base@sha256:fa70d211e884a7348b53ff0120eed1f8070f053dd4a1c4b0bfeec74e1a42c5b0
+
+ARG IMAGE_NAME
+ARG IMAGE_TAG
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_VENDOR
+ARG IMAGE_URL
+ARG IMAGE_MAINTAINER
+
+LABEL org.opencontainers.image.title="${IMAGE_NAME}" \
+	org.opencontainers.image.description="${IMAGE_DESCRIPTION}" \
+	org.opencontainers.image.authors="${IMAGE_MAINTAINER}" \
+	org.opencontainers.image.vendor="${IMAGE_VENDOR}" \
+	org.opencontainers.image.url="${IMAGE_URL}" \
+	org.opencontainers.image.version="${IMAGE_TAG}"
+
+ARG BOWHEAD_VERSION
+RUN wget https://github.com/PacificBiosciences/bowhead/releases/download/v${BOWHEAD_VERSION}/bowhead-v${BOWHEAD_VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
+	tar --no-same-owner -zxvf bowhead-v${BOWHEAD_VERSION}-x86_64-unknown-linux-gnu.tar.gz --directory /opt && \
+	rm bowhead-v${BOWHEAD_VERSION}-x86_64-unknown-linux-gnu.tar.gz
+RUN ln -s /opt/bowhead-v${BOWHEAD_VERSION}-x86_64-unknown-linux-gnu/bowhead /usr/local/bin/
+
+RUN bowhead --version

--- a/docker/bowhead/build.env
+++ b/docker/bowhead/build.env
@@ -1,0 +1,14 @@
+# Image revision
+IMAGE_BUILD=1
+
+# Tool versions
+BOWHEAD_VERSION=0.2.0
+
+# Image info
+IMAGE_NAME=bowhead
+IMAGE_TAG=${BOWHEAD_VERSION}_build${IMAGE_BUILD}
+
+IMAGE_DESCRIPTION="An oncology toolkit for PacBio HiFi sequencing"
+IMAGE_VENDOR="Pacific Biosciences"
+IMAGE_URL="https://github.com/PacificBiosciences/wdl-dockerfiles"
+IMAGE_MAINTAINER="Billy Rowell <wrowell@pacb.com>, Matt Holt <mholt@pacb.com>"


### PR DESCRIPTION
```
0.2.0_build1: digest: sha256:fc987d072a4d796ffe6bb5cd1cb56e525e35d247988f8bcebee7c87d23e0c8b1
```

Build locally tested and binary seemingly works.