### PR TITLE
bump: update kivvi to 1.1.0

### DIFF
--- a/docker/kivvi/Dockerfile
+++ b/docker/kivvi/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pacbio/pb_wdl_base@sha256:fa70d211e884a7348b53ff0120eed1f8070f053dd4a1c4b0bfeec74e1a42c5b0
+FROM quay.io/pacbio/pb_wdl_base@sha256:03cb3c01937eccc907f8ad71c87b258581504572205fe3f31a657e318f3564ae
 
 ARG IMAGE_NAME
 ARG IMAGE_TAG

--- a/docker/kivvi/build.env
+++ b/docker/kivvi/build.env
@@ -1,8 +1,8 @@
 # Image revision
-IMAGE_BUILD=2
+IMAGE_BUILD=1
 
 # Tool versions
-KIVVI_VERSION=1.0.0
+KIVVI_VERSION=1.1.0
 
 # Image info
 IMAGE_NAME=kivvi


### PR DESCRIPTION
1.1.0_build1: digest: sha256:9e4a390821ea999af9b3faa483c5f7dce58041c439a35e4af3676f25edecd204