### PR TITLE
bump: update mitorsaw to 0.2.13

### DIFF
--- a/docker/mitorsaw/Dockerfile
+++ b/docker/mitorsaw/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pacbio/pb_wdl_base@sha256:fa70d211e884a7348b53ff0120eed1f8070f053dd4a1c4b0bfeec74e1a42c5b0
+FROM quay.io/pacbio/pb_wdl_base@sha256:03cb3c01937eccc907f8ad71c87b258581504572205fe3f31a657e318f3564ae
 
 ARG IMAGE_NAME
 ARG IMAGE_TAG

--- a/docker/mitorsaw/build.env
+++ b/docker/mitorsaw/build.env
@@ -1,8 +1,8 @@
 # Image revision
-IMAGE_BUILD=2
+IMAGE_BUILD=1
 
 # Tool versions
-MITORSAW_VERSION=0.2.7
+MITORSAW_VERSION=0.2.13
 
 # Image info
 IMAGE_NAME=mitorsaw
@@ -12,3 +12,4 @@ IMAGE_DESCRIPTION="A tool for mitochondrial analysis for HiFi sequencing data"
 IMAGE_VENDOR="Pacific Biosciences"
 IMAGE_URL="https://github.com/PacificBiosciences/wdl-dockerfiles"
 IMAGE_MAINTAINER="Billy Rowell <wrowell@pacb.com>, Matt Holt <mholt@pacb.com>"
+


### PR DESCRIPTION
0.2.13_build1: digest: sha256:9b610f343ae018b21c86977259d91dba587e1f22d7a73e115937e428d3c7adeb